### PR TITLE
Traders and research

### DIFF
--- a/Defs/ResearchProjectDefs/AdvancedResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/AdvancedResearchProjects.xml
@@ -8,6 +8,8 @@
 		<baseCost>700</baseCost>
 		<techLevel>Industrial</techLevel>
 		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>7</researchViewX>
+		<researchViewY>0.8</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -23,6 +25,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>9</researchViewX>
+		<researchViewY>1</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -35,6 +39,9 @@
 		</prerequisites>
 		<techLevel>Industrial</techLevel>
 		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>8</researchViewX>
+		<researchViewY>1.6</researchViewY>
+
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -47,6 +54,8 @@
 		</prerequisites>
 		<techLevel>Industrial</techLevel>
 		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>8</researchViewX>
+		<researchViewY>0.8</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -62,6 +71,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>10</researchViewX>
+		<researchViewY>1</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -77,6 +88,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>8</researchViewX>
+		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -92,6 +105,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>9</researchViewX>
+		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -107,6 +122,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>10</researchViewX>
+		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -122,6 +139,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>11</researchViewX>
+		<researchViewY>0.8</researchViewY>
 	</ResearchProjectDef> 
 
 	<ResearchProjectDef>
@@ -137,6 +156,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>11</researchViewX>
+		<researchViewY>1.6</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -152,6 +173,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>11</researchViewX>
+		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -167,6 +190,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>12</researchViewX>
+		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef>
@@ -182,6 +207,8 @@
 		<requiredResearchFacilities>
 			<li>MultiAnalyzer</li>
 		</requiredResearchFacilities>
+		<researchViewX>10</researchViewX>
+		<researchViewY>2</researchViewY>
 	</ResearchProjectDef>
 
 </ResearchProjectDefs>

--- a/Defs/ResearchProjectDefs/DisplaceCoreResearchProjects.xml
+++ b/Defs/ResearchProjectDefs/DisplaceCoreResearchProjects.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ResearchProjectDef>
+		<defName>TransportPod</defName>
+		<label>transport pod</label>
+		<description>Construct launchable transport pods that you can use to launch people and supplies long distances across the planet's surface.</description>
+		<baseCost>1100</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>MicroelectronicsBasics</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>7</researchViewX>
+		<researchViewY>2.5</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef>
+		<defName>HospitalBed</defName>
+		<label>hospital bed</label>
+		<description>Allows colonists to construct hospital beds which increase chance of successful medical work.</description>
+		<baseCost>2000</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>MicroelectronicsBasics</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>7</researchViewX>
+		<researchViewY>1.6</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef>
+		<defName>MultiAnalyzer</defName>
+		<label>multi-analyzer</label>
+		<description>Allows colonists to build multi-analyzers which increase research speed, and allow higher-level research projects, if placed near a research bench.</description>
+		<baseCost>800</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>MicroelectronicsBasics</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<researchViewX>8</researchViewX>
+		<researchViewY>2.4</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef>
+		<defName>VitalsMonitor</defName>
+		<label>vitals monitor</label>
+		<description>Allows colonists to build vitals monitors which increase patients treatment quality if placed next to medical beds.</description>
+		<baseCost>1600</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>MultiAnalyzer</li>
+			<li>HospitalBed</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<requiredResearchFacilities>
+			<li>MultiAnalyzer</li>
+		</requiredResearchFacilities>
+		<researchViewX>9</researchViewX>
+		<researchViewY>2</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef>
+		<defName>GroundPenetratingScanner</defName>
+		<label>ground-penetrating scanner</label>
+		<description>Allows you to build ground-penetrating scanners that can detect drillable resources deep under the surface.</description>
+		<baseCost>7000</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>DeepDrilling</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<requiredResearchFacilities>
+			<li>MultiAnalyzer</li>
+		</requiredResearchFacilities>
+		<researchViewX>11</researchViewX>
+		<researchViewY>5</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef>
+		<defName>DeepDrilling</defName>
+		<label>deep drilling</label>
+		<description>Allows you to build deep drills for extracting resources from deep underground. You'll need a ground-penetrating scanner to find the resources.</description>
+		<baseCost>1500</baseCost>
+		<techLevel>Industrial</techLevel>
+		<prerequisites>
+			<li>MultiAnalyzer</li>
+		</prerequisites>
+		<requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
+		<requiredResearchFacilities>
+			<li>MultiAnalyzer</li>
+		</requiredResearchFacilities>
+		<researchViewX>10</researchViewX>
+		<researchViewY>5</researchViewY>
+	</ResearchProjectDef>
+
+	<ResearchProjectDef ParentName="ShipResearchProjectBase">
+		<defName>ShipBasics</defName>
+		<label>shipbuilding basics</label>
+		<description>Allows you to start researching more advanced shipbuilding technologies and eventually build a ship to escape the planet.</description>
+		<baseCost>1000</baseCost>
+		<techLevel>Spacer</techLevel>
+		<prerequisites>
+			<li>MultiAnalyzer</li>
+		</prerequisites>
+		<researchViewX>11</researchViewX>
+		<researchViewY>2.5</researchViewY>
+	</ResearchProjectDef>
+
+</Defs>

--- a/Defs/TraderKindDefs/GT_Trader.xml
+++ b/Defs/TraderKindDefs/GT_Trader.xml
@@ -115,7 +115,7 @@
 				</countRange>
 			</li>
 			<li Class="StockGenerator_Tag">
-				<tradeTag>BodyPart</tradeTag>
+				<tradeTag>BodyPartOrImplant</tradeTag>
 				<thingDefCountRange>
 					<min>2</min>
 					<max>5</max>


### PR DESCRIPTION
1) Fixed incorrect reference in BlackMarket traders: they were referencing BodyPart trade tag, but new bionics has BodyPartOrImplant tag.
2) Added coordinates for nicer research tree layout. Extra file moves existing Core research items to reduce the number of dependency line intersections.